### PR TITLE
Make script compatible with jQuery 3.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -68,7 +68,7 @@
     })();
 
     // divides container once image is loaded
-    $("li:first-child>img", $turntable).load(function () {
+    $("li:first-child>img", $turntable).on("load", function () {
       $(this).parent().addClass('active');
       divideContainer($listItems);
     });


### PR DESCRIPTION
Fixes #12 
jQuery 3 has deprecated `.load` event in favour of `.on("load", eventHandler)`.
This pull request replaces the only instance of `.load` with the new syntax.
Tested with jQuery 3.2.1 and 1.9.1 for retrocompatibility.